### PR TITLE
Banner options and osx features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore RSA keys and log files
+bin/
+temp/
 ssh-honeypot.*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,20 @@
+### Linux
+Make sure libssh is installed
+
+    $ apt install libssh-dev
+
+### OSX
+Make sure that xcode is up to date. Then,
+
+
+Install libssh
+
+    $ brew install libssh
+
+Copy the osx makefile over Makefile
+
+    $ mv MakefileOSX Makefile
+
+## Build
+
+    $ make

--- a/MakefileOSX
+++ b/MakefileOSX
@@ -1,0 +1,10 @@
+CC=clang
+CFLAGS=-DLIBSSH_STATIC
+INC=-I/usr/local/opt/libssh/include
+LIBS=-L/usr/local/opt/libssh/lib -lssh
+
+ssh-honeypot:
+	$(CC) $(CFLAGS) -o bin/ssh-honeypot src/ssh-honeypot.c $(INC) $(LIBS)
+
+clean:
+	rm -f *~ src/*~ bin/ssh-honeypot src/*.o

--- a/README.md
+++ b/README.md
@@ -4,12 +4,35 @@ This program listens for incoming ssh connections and logs the ip
 address, username, and password used. This was written to gather
 rudimentary intelligence on brute force attacks.
 
-## Quick start
-- ensure libssh is installed (apt install libssh-dev)
-- edit src/config.h
-- ssh-keygen -t rsa (save to non-default location!)
-- make
-- bin/ssh-honeypot -r ssh-honeypot.rsa
+## Quickstart
+
+### Linux
+Make sure libssh is installed
+
+    $ apt install libssh-dev
+
+### OSX
+Make sure that xcode is up to date. Then,
+
+
+Install libssh
+
+    $ brew install libssh
+
+Copy the osx makefile over Makefile
+
+    $ mv MakefileOSX Makefile
+
+## Build and Run
+
+    $ make
+    $ ssh-keygen -t rsa -f ./ssh-honeypot.rsa
+    $ bin/ssh-honeypot -r ./ssh-honepot.rsa
+
+
+## Usage
+
+    $ bin/ssh-keygen -h
 
 ## Syslog facilities.
 
@@ -22,3 +45,16 @@ leakage.
 
 This was implemented to aggregate the data from several hosts into
 a centralized spot.
+
+## Banners
+List available banners
+
+    $ bin/ssh-keygen -b
+
+Set banner string
+
+    $ bin/ssh-keygen -b "mybanner string"
+
+Set banner by index
+
+    $ bib/ssh-keygen -i <banner index>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Copy the osx makefile over Makefile
 
 ## Usage
 
-    $ bin/ssh-keygen -h
+    $ bin/ssh-honeypot -h
 
 ## Syslog facilities.
 
@@ -49,12 +49,12 @@ a centralized spot.
 ## Banners
 List available banners
 
-    $ bin/ssh-keygen -b
+    $ bin/ssh-honeypot -b
 
 Set banner string
 
-    $ bin/ssh-keygen -b "mybanner string"
+    $ bin/ssh-honeypot -b "my banner string"
 
 Set banner by index
 
-    $ bib/ssh-keygen -i <banner index>
+    $ bib/ssh-honeypot -i <banner index>

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-- gather more SSH banners and add ability to select
+- gather more SSH banners
 - log parsing scripts
 -- geolocation
 -- graphs/statistics

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/src/config.h
+++ b/src/config.h
@@ -6,6 +6,3 @@
 #define PORT     22                              /* default port */
 #define RSAKEY   "ssh-honeypot.rsa"              /* default RSA key */
 #define BINDADDR "0.0.0.0"                       /* default bind address */
-#define BANNER   "OpenSSH_7.2p2 Ubuntu-4ubuntu2.1" /* fake Ubuntu 16.04 */
-//#define BANNER  "OpenSSH_6.6.1"                    /* openSUSE 42.1 */
-//#define BANNER  "OpenSSH_6.7p1 Debian-5+deb8u3"    /* Debian 8.6 */


### PR DESCRIPTION
### Banners Option

Added ability to select from the list of banner messages using -i option.

First, list available banner messages using

    $ ssh-honeypot -b

Then, select a banner message by index

    $ ssh-honeypot -i 2 -r ...

Alternately, specify a custom banner message with a string

    $ ssh-honeypot -b "my banner message here!" -r ...

### OSX

Added ability to build on OSX. Readme and install files were updated to reflect this.