### PR TITLE
Fix parsing bind address option

### DIFF
--- a/src/ssh-honeypot.c
+++ b/src/ssh-honeypot.c
@@ -465,7 +465,7 @@ int main (int argc, char *argv[]) {
   ssh_bind		sshbind;
 
 
-  while ((opt = getopt (argc, argv, "h?p:dLl:b:i:r:f:su:j:J:P:")) != -1) {
+  while ((opt = getopt (argc, argv, "h?p:dLla::b:i:r:f:su:j:J:P:")) != -1) {
     switch (opt) {
     case 'p': /* Listen port */
       port = atoi(optarg);

--- a/src/ssh-honeypot.c
+++ b/src/ssh-honeypot.c
@@ -465,7 +465,7 @@ int main (int argc, char *argv[]) {
   ssh_bind		sshbind;
 
 
-  while ((opt = getopt (argc, argv, "h?p:dLla::b:i:r:f:su:j:J:P:")) != -1) {
+  while ((opt = getopt (argc, argv, "h?p:dLl:a:b:i:r:f:su:j:J:P:")) != -1) {
     switch (opt) {
     case 'p': /* Listen port */
       port = atoi(optarg);


### PR DESCRIPTION
The option `-a` was missing in `getopt`.