### PR TITLE
Add Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Specify MakefileOSX with make:
 
 
 
-### Docker
+### Docker (experimental)
 
-Please take a look at our Docker documentation. 
+Please take a look at our [Docker documentation](docker/README.md). 
 
 
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Specify MakefileOSX with make:
 
     $ make -f MakefileOSX
 
+
+
+### Docker
+
+Please take a look at our Docker documentation. 
+
+
+
 ## Build and Run
 
     $ make
@@ -56,7 +64,7 @@ on port 22 for example instead of root, but have to initially start it
 as root:
 
 	$ sudo bin/ssh-honeypot -p 22 -u nobody
-	
+
 Beware that this chowns the logfile to the user specified as well.
 
 ## Changing the Banner

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.12 AS build
 
 RUN apk add --update alpine-sdk clang git libssh-dev openssl openssh json-c-dev libssh2-dev \
-    && git clone https://github.com/droberson/ssh-honeypot.git /git-ssh-honeypot \
+    && git clone --depth=1 --single-branch -j "$(nproc)" https://github.com/droberson/ssh-honeypot.git /git-ssh-honeypot \
     && cd /git-ssh-honeypot \
-    && make \
+    && make -j "$(nproc)" \
     && chmod 0777 ./bin/ssh-honeypot
 
 # ====== APP ======

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:3.12 AS build
+
+RUN apk add --update alpine-sdk clang git libssh-dev openssl openssh json-c-dev libssh2-dev \
+    && git clone https://github.com/droberson/ssh-honeypot.git /git-ssh-honeypot \
+    && cd /git-ssh-honeypot \
+    && make \
+    && chmod 0777 ./bin/ssh-honeypot
+
+# ====== APP ======
+FROM nlss/base-alpine:3.12
+
+COPY --from=build /git-ssh-honeypot/bin/ssh-honeypot /bin/ssh-honeypot
+
+RUN apk add --update --no-cache libssh-dev json-c-dev openssh \
+    && adduser --shell /bin/false --disabled-password --gecos "Honeycomb" --home "/home/honeycomb" "honeycomb" \
+    && mkdir -p /home/honeycomb/{log,rsa}
+
+COPY ["./rootfs", "/"]
+
+VOLUME ["/home/honeycomb/log", "/home/honeycomb/rsa"]
+
+EXPOSE 2022/TCP

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ docker-compose build
 To run: 
 
 ```
-docker-compose up
+docker-compose -p ssh-honeypot up
 ```
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,42 @@
+# SSH Honeypot Docker
+
+### Build and Deploy
+
+To build: 
+
+```
+docker-compose build
+```
+
+To run: 
+
+```
+docker-compose up
+```
+
+
+
+### Environment variables
+
+Certain amount of control is given through following environment variables
+
+```
+- SSH_BANNER                          # Value set here will be passed as -b argument to the service
+- SSH_BANNER_INDEX                    # Value set here will be passed as -i argument to the service
+- SSH_JSON_LOG_SERVER                 # Value set here will be passed as -J argument to the service
+- SSH_JSON_LOG_SERVER_PORT            # Value set here will be passed as -P argument to the service
+```
+
+
+
+### Volumes
+
+Following paths are mounted as volumes by default
+
+```
+- /home/honeycomb/log       # Log files
+- /home/honeycomb/rsa       # Generated RSA key is held here. If you have your own key, you can replace sshd-key.rsa file
+```
+
+* As per docker support, any additional path(s) can be mounted as volume(s); Note that this could have side-effects.
+* RSA key is generated during stage 2. If file already exists, it will not be generated again. 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '2'
+services:
+  ssh-honeypot:
+    image: 'local/ssh-honeypot:latest'
+    build: .
+    ports:
+      - '22:2022'
+    volumes:
+      - log:/home/honeycomb/log
+      - rsa:/home/honeycomb/rsa     
+    networks:
+      default: 
+    restart: unless-stopped
+
+volumes:
+  log:
+    driver: local
+  rsa:
+    driver: local
+
+networks:
+  default:

--- a/docker/rootfs/bin/ssh-honeypot-wrapper
+++ b/docker/rootfs/bin/ssh-honeypot-wrapper
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -e
+
+# Initial arguments that ssh-honeypot will be started with
+# Intentionally added one by one for more clarity
+P_INIT_ARGS="-r /home/honeycomb/rsa/sshd-key.rsa"
+P_INIT_ARGS="${P_INIT_ARGS} -p 2022"
+P_INIT_ARGS="${P_INIT_ARGS} -j /home/honeycomb/log/honeypot.json"
+
+# Show banner by either string or index
+if [ -n "${SSH_BANNER}" ]; then
+  P_INIT_ARGS="${P_INIT_ARGS} -b '${SSH_BANNER}'"
+elif [ -n "${SSH_BANNER_INDEX}" ]; then
+  P_INIT_ARGS="${P_INIT_ARGS} -i '${SSH_BANNER_INDEX}'"
+fi
+
+# Should we send log to JSON log server
+if [ -n "${SSH_JSON_LOG_SERVER}" ]; then
+  P_INIT_ARGS="${P_INIT_ARGS} -J '${SSH_JSON_LOG_SERVER}'"
+
+  # JSON server port
+  if [ -n "${SSH_JSON_LOG_SERVER_PORT}" ]; then
+    P_INIT_ARGS="${P_INIT_ARGS} -P '${SSH_JSON_LOG_SERVER_PORT}'"
+  fi
+
+fi
+
+exec /bin/ssh-honeypot ${P_INIT_ARGS} -u honeycomb

--- a/docker/rootfs/etc/cont-init.d/10-generate-rsa-key
+++ b/docker/rootfs/etc/cont-init.d/10-generate-rsa-key
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -e
+
+RSA_KEY="/home/honeycomb/rsa/sshd-key.rsa"
+
+if [ -f "${RSA_KEY}" ]; then
+  exit 0
+fi
+
+ssh-keygen -t rsa -f "${RSA_KEY}" -q -N ""
+chown honeycomb:honeycomb "${RSA_KEY}"

--- a/docker/rootfs/etc/fix-attrs.d/00-exec-permissions
+++ b/docker/rootfs/etc/fix-attrs.d/00-exec-permissions
@@ -1,0 +1,3 @@
+/bin/ssh-honeypot true root 0775 0775
+/bin/ssh-honeypot-wrapper true root 0775 0775
+/etc/services.d/sshd/run true root 0775 0775

--- a/docker/rootfs/etc/fix-attrs.d/10-fix-home-ownership
+++ b/docker/rootfs/etc/fix-attrs.d/10-fix-home-ownership
@@ -1,0 +1,1 @@
+/home/honeycomb true honeycomb 2770 2770

--- a/docker/rootfs/etc/services.d/sshd/finish
+++ b/docker/rootfs/etc/services.d/sshd/finish
@@ -1,0 +1,2 @@
+#!/usr/bin/execlineb -P
+s6-svscanctl -t /var/run/s6/services

--- a/docker/rootfs/etc/services.d/sshd/run
+++ b/docker/rootfs/etc/services.d/sshd/run
@@ -1,0 +1,2 @@
+#!/usr/bin/execlineb -P
+/bin/ssh-honeypot-wrapper


### PR DESCRIPTION
Docker is evolving more and more, and the number of people choosing this technology is steadily increasing. 
 
I am not exempt; I wanted to use this project as a decoy running on port 22, as my real SSH port is something different. The problem popped up, almost immediately: My architecture is running containers exclusively, and this project doesn't have docker support. 

A quick google search revealed [this](https://github.com/random-robbie/docker-ssh-honey), but it's outdated and not optimized. 
So... I made my own, inspired by repo above; Here are my 5 cents. 

S6 supervised Alpine based docker image. Image size is <u>only</u> ~22 MB. 

There are some things left, like multi-arch support; Currently, only x86-64 is supported, but that is to be added on [my base image](https://github.com/N0rthernL1ghts/base-alpine), which I'm planning to do soon.  


---
You should configure automated builds somewhere, preferably Docker hub, and update docker/README.MD and docker/docker-compose.yml with new image names. Or let me know and I'll update that. 

Cheers