### PR TITLE
Update build and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ make
 ssh-keygen -t rsa -f ./ssh-honeypot.rsa
 bin/ssh-honeypot -r ./ssh-honeypot.rsa
 ```
+*Note:* Make might show a warning related to `ssh_message_auth_password` being deprecated. The binary is still being created, check `/bin/ssh-honeypot`.
 
 ### OSX (experimental/unsupported)
 


### PR DESCRIPTION
closes #31 

A suggestion to add this note to the instruction. It is helpful for folks not familiar with C and prevents useless debugging.