### PR TITLE
GitHub Actions and fixed Docker

### DIFF
--- a/.github/workflows/auto-create-release.yaml
+++ b/.github/workflows/auto-create-release.yaml
@@ -1,0 +1,28 @@
+name: Draft release
+
+on:
+  push:
+    tags:
+
+jobs:
+  auto-prep-release:
+    name: Auto prep release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Make release if missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view ${{ github.ref_name }} > /dev/null; then
+            echo "Release ${{ github.ref_name }} exists."
+            exit 0
+          fi
+
+          echo "Creating release ${{ github.ref_name }}..."
+          gh release create \
+            --generate-notes \
+            ${{ github.ref_name }}

--- a/.github/workflows/build-application.yaml
+++ b/.github/workflows/build-application.yaml
@@ -10,6 +10,10 @@ on:
     branches:
       - master
 
+env:
+  CONTAINER_REGISTRY: ghcr.io
+  CONTAINER_NAME: ${{ github.repository }}
+
 permissions:
   contents: write
   attestations: write
@@ -48,3 +52,51 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} bin/ssh-honeypot
+
+  build-and-push-image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_NAME }}
+          tags: |
+            type=edge,branch=master
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.CONTAINER_REGISTRY }}/${{ env.CONTAINER_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-application.yaml
+++ b/.github/workflows/build-application.yaml
@@ -11,7 +11,9 @@ on:
       - master
 
 permissions:
-  contents: read
+  contents: write
+  attestations: write
+  id-token: write
 
 jobs:
   build-linux:
@@ -33,3 +35,16 @@ jobs:
         with:
           name: ssh-honeypot
           path: bin/ssh-honeypot
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        if: github.ref_type == 'tag'
+        with:
+          subject-path: bin/ssh-honeypot
+
+      - name: Publish with release
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} bin/ssh-honeypot

--- a/.github/workflows/build-application.yaml
+++ b/.github/workflows/build-application.yaml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build-linux:
+    name: Build Linux binary
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt install libssh-dev libjson-c-dev libpcap-dev libssl-dev
+
+      - name: Build application
+        run: make
+
+      - name: Publish binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ssh-honeypot
+          path: bin/ssh-honeypot

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,41 @@
 FROM alpine:3.12 AS build
 
-RUN apk add --update alpine-sdk clang git libssh-dev openssl openssh json-c-dev libssh2-dev \
-    && git clone --depth=1 --single-branch -j "$(nproc)" https://github.com/droberson/ssh-honeypot.git /git-ssh-honeypot \
+RUN apk add --update \
+	alpine-sdk \
+	clang git \
+	libssh-dev \
+	openssl \
+	openssh \
+	json-c-dev \
+	libssh2-dev \
+	libpcap-dev
+
+RUN git clone \
+	--depth=1 \
+	--single-branch \
+	-j "$(nproc)" \
+	https://github.com/droberson/ssh-honeypot.git /git-ssh-honeypot \
     && cd /git-ssh-honeypot \
     && make -j "$(nproc)" \
     && chmod 0777 ./bin/ssh-honeypot
 
 # ====== APP ======
-FROM nlss/base-alpine:3.12
+FROM alpine:3.12
 
-COPY --from=build /git-ssh-honeypot/bin/ssh-honeypot /bin/ssh-honeypot
+COPY --from=build \
+	/git-ssh-honeypot/bin/ssh-honeypot \
+	/bin/ssh-honeypot
 
-RUN apk add --update --no-cache libssh-dev json-c-dev openssh \
-    && adduser --shell /bin/false --disabled-password --gecos "Honeycomb" --home "/home/honeycomb" "honeycomb" \
+RUN apk add --update --no-cache \
+	libssh-dev \
+	json-c-dev \
+	openssh \
+    && adduser \
+	--shell /bin/false \
+	--disabled-password \
+	--gecos "Honeycomb" \
+	--home "/home/honeycomb" \
+	"honeycomb" \
     && mkdir -p /home/honeycomb/{log,rsa}
 
 COPY ["./rootfs", "/"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ networks:
 
 services:
   ssh-honeypot:
-    image: 'local/ssh-honeypot:latest'
+    image: 'ghcr.io/droberson/ssh-honeypot:latest'
     build: .
     ports:
       - '22:2022'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,6 @@
-version: '2'
+networks:
+  default:
+
 services:
   ssh-honeypot:
     image: 'local/ssh-honeypot:latest'
@@ -9,7 +11,7 @@ services:
       - log:/home/honeycomb/log
       - rsa:/home/honeycomb/rsa     
     networks:
-      default: 
+      - default
     restart: unless-stopped
 
 volumes:
@@ -17,6 +19,3 @@ volumes:
     driver: local
   rsa:
     driver: local
-
-networks:
-  default:


### PR DESCRIPTION
This adds GitHub Actions support and fixes the Dockerfile

- binaries built on tags, pushes to master and with PRs
- binaries attested and attached to a release whenever you push a tag
- docker image created from master (`edge`) and on releases (`latest`)

I ran into some issues while trying to roll this out on my server, so I fixed those and wanted to test the Docker image.

Glad to help :) 